### PR TITLE
fix read_batch behavior for visgeno testing

### DIFF
--- a/exp-visgeno-rel/exp_test_visgeno_attbilstm.py
+++ b/exp-visgeno-rel/exp_test_visgeno_attbilstm.py
@@ -74,6 +74,15 @@ total = 0
 # Run optimization
 for n_iter in range(reader.num_batch):
     batch = reader.read_batch()
+
+    ###
+    # continue if the batch does not contain any relationship
+    # and increment n_iter so that the first few batches are not read once again in case of
+    ###
+    if batch is None:
+        n_iter = n_iter + 1
+        continue
+
     print('\tthis batch: N_lang = %d, N_bbox = %d' %
           (batch['expr_obj1_batch'].shape[1], batch['bbox_batch'].shape[0]))
 

--- a/exp-visgeno-rel/exp_test_visgeno_baseline.py
+++ b/exp-visgeno-rel/exp_test_visgeno_baseline.py
@@ -72,6 +72,15 @@ total = 0
 # Run test
 for n_iter in range(reader.num_batch):
     batch = reader.read_batch()
+
+    ###
+    # continue if the batch does not contain any relationship
+    # and increment n_iter so that the first few batches are not read once again in case of
+    ###
+    if batch is None:
+        n_iter = n_iter + 1
+        continue
+        
     print('\tthis batch: N_lang = %d, N_bbox = %d' %
           (batch['expr_obj1_batch'].shape[1], batch['bbox_batch'].shape[0]))
 

--- a/exp-visgeno-rel/exp_test_visgeno_pair_attbilstm.py
+++ b/exp-visgeno-rel/exp_test_visgeno_pair_attbilstm.py
@@ -71,6 +71,15 @@ total = 0
 # Run optimization
 for n_iter in range(reader.num_batch):
     batch = reader.read_batch()
+
+    ###
+    # continue if the batch does not contain any relationship
+    # and increment n_iter so that the first few batches are not read once again in case of
+    ###
+    if batch is None:
+        n_iter = n_iter + 1
+        continue
+        
     print('\tthis batch: N_lang = %d, N_bbox = %d' %
           (batch['expr_obj1_batch'].shape[1], batch['bbox_batch'].shape[0]))
 

--- a/exp-visgeno-rel/exp_test_visgeno_pair_baseline.py
+++ b/exp-visgeno-rel/exp_test_visgeno_pair_baseline.py
@@ -87,6 +87,15 @@ total = 0
 # Run test
 for n_iter in range(reader.num_batch):
     batch = reader.read_batch()
+
+    ###
+    # continue if the batch does not contain any relationship
+    # and increment n_iter so that the first few batches are not read once again in case of
+    ###
+    if batch is None:
+        n_iter = n_iter + 1
+        continue
+        
     print('\tthis batch: N_lang = %d, N_bbox = %d' %
           (batch['expr_obj1_batch'].shape[1], batch['bbox_batch'].shape[0]))
 

--- a/util/visgeno_rel_train/rel_data_reader.py
+++ b/util/visgeno_rel_train/rel_data_reader.py
@@ -31,6 +31,7 @@ def run_prefetch(prefetch_queue, imdb, im_mean, min_size, max_size, vocab_dict,
         except IOError as err:
             # Print error and move on to next batch
             print('data reader: skipped an image.', err)
+            prefetch_queue.put(None, block=True)
 
         # Move to next batch
         n_batch_prefetch = (n_batch_prefetch + 1) % num_batch
@@ -76,7 +77,7 @@ class DataReader:
         self.prefetch_thread.start()
 
     def read_batch(self):
-        print('data reader: epoch = %d, batch = %d / %d' % (self.n_epoch, self.n_batch, self.num_batch))
+        print('data reader: epoch = %d, batch = %d / %d' % (self.n_epoch, self.n_batch + 1, self.num_batch))
 
         # Get a batch from the prefetching queue
         if self.prefetch_queue.empty():


### PR DESCRIPTION
### Testing scripts in exp-visgeno-rel

The `DataReader` allows to read the same batch several times even at testing time, if a batch raises an IOError in `run_prefetch` from `util/visgeno_rel_train/rel_data_reader.py`, it does not increment `self.n_batch` causing the reader to eventually read the first batch once again without incrementing `self.n_epoch`.

For example in `exp-visgeno-rel/exp_test_visgeno_attbilstm.py`, the test runs over `reader.num_batch` (equals 5000 in case of **imdb_tst**) but 127 batches of **imdb_tst** does not contain any relationship causing `prepare_batch` to raise an IOError, caught by `run_prefetch` and it does not do anything in that case. Eventually the first 127 batches of **imdb_tst** are read and been computed scores once again. I think this is not an intended behavior, rather `exp_test_visgeno_attbilstm.py` (and other testing scripts) should compute scores against batches containing relationships only once. 

To solve the problem, I suggest that `run_prefetch` adds **None** to the **prefetch_queue** in case of an "empty" batch. 

```python
# from run_prefetch in util/visgeno_rel_train/rel_data_reader.py
except IOError as err:
            # Print error and move on to next batch
            print('data reader: skipped an image.', err)
            prefetch_queue.put(None, block=True)
```


In testing scripts such as `exp_test_visgeno_attbilstm.py` if read_batch is **None** `n_iter` is incremented and we move to the next batch.

```python
# from exp_test_visgeno_attbilstm.py in exp-visgeno-rel/exp_test_visgeno_attbilstm.py
for n_iter in range(reader.num_batch):
    batch = reader.read_batch()

    ###
    # continue if the batch does not contain any relationship
    # and increment n_iter so that the first few batches are not read once again in case of
    ###
    if batch is None:
        n_iter = n_iter + 1
        continue

    # compute score for batch
```